### PR TITLE
Add column accessors to Statement

### DIFF
--- a/FeistyDB/ColumnConvertible.swift
+++ b/FeistyDB/ColumnConvertible.swift
@@ -124,17 +124,16 @@ extension Statement {
 	///
 	/// - note: Column indexes are 0-based.  The leftmost column in a row has index 0.
 	///
-	/// - requires: `indexes.startIndex >= 0`
-	/// - requires: `indexes.endIndex < self.columnCount`
+	/// - requires: `indexes.min() >= 0`
+	/// - requires: `indexes.max() < self.columnCount`
 	///
 	/// - parameter indexes: The indexes of the desired column
 	///
 	/// - throws: An error if any element of `indexes` is out of bounds
-	public func columns<T: ColumnConvertible>(_ indexes: IndexSet) throws -> [[T]] {
+	public func columns<S: Collection, T: ColumnConvertible>(_ indexes: S) throws -> [[T]] where S.Element == Int {
 		var values = [[T]](repeating: [], count: indexes.count)
-		let sequence = indexes.enumerated()
 		try results { row in
-			for (n, x) in sequence {
+			for (n, x) in indexes.enumerated() {
 				values[n].append(try row.value(at: x))
 			}
 		}

--- a/FeistyDB/ColumnConvertible.swift
+++ b/FeistyDB/ColumnConvertible.swift
@@ -127,7 +127,7 @@ extension Statement {
 	/// - requires: `indexes.min() >= 0`
 	/// - requires: `indexes.max() < self.columnCount`
 	///
-	/// - parameter indexes: The indexes of the desired column
+	/// - parameter indexes: The indexes of the desired columns
 	///
 	/// - throws: An error if any element of `indexes` is out of bounds
 	public func columns<S: Collection, T: ColumnConvertible>(_ indexes: S) throws -> [[T]] where S.Element == Int {

--- a/FeistyDB/ColumnConvertible.swift
+++ b/FeistyDB/ColumnConvertible.swift
@@ -120,6 +120,27 @@ extension Row {
 }
 
 extension Statement {
+	/// Returns the values of the columns at `indexes` for each row in the result set.
+	///
+	/// - note: Column indexes are 0-based.  The leftmost column in a row has index 0.
+	///
+	/// - requires: `indexes.startIndex >= 0`
+	/// - requires: `indexes.endIndex < self.columnCount`
+	///
+	/// - parameter indexes: The indexes of the desired column
+	///
+	/// - throws: An error if any element of `indexes` is out of bounds
+	public func columns<T: ColumnConvertible>(_ indexes: IndexSet) throws -> [[T]] {
+		var values = [[T]](repeating: [], count: indexes.count)
+		let sequence = indexes.enumerated()
+		try results { row in
+			for (n, x) in sequence {
+				values[n].append(try row.value(at: x))
+			}
+		}
+		return values
+	}
+
 	/// Returns the value of the column at `index` for each row in the result set.
 	///
 	/// - note: Column indexes are 0-based.  The leftmost column in a row has index 0.

--- a/FeistyDB/ColumnConvertible.swift
+++ b/FeistyDB/ColumnConvertible.swift
@@ -120,17 +120,33 @@ extension Row {
 }
 
 extension Statement {
+	/// Returns the value of the column at `index` for each row in the result set.
+	///
+	/// - note: Column indexes are 0-based.  The leftmost column in a row has index 0.
+	///
+	/// - requires: `index >= 0`
+	/// - requires: `index < self.columnCount`
+	///
+	/// - parameter index: The index of the desired column
+	///
+	/// - throws: An error if `index` is out of bounds or the column contains a null or illegal value
+	public func column<T: ColumnConvertible>(_ index: Int) throws -> [T] {
+		var values = [T]()
+		try results { row in
+			values.append(try row.value(at: index))
+		}
+		return values
+	}
+
 	/// Returns the value of the leftmost column for each row in the result set.
+	///
+	/// This is a shortcut for `column(0)`.
 	///
 	/// - throws: An error if there are no columns
 	///
 	/// - returns: An array containing the leftmost column's values
 	public func leftmostColumn<T: ColumnConvertible>() throws -> [T] {
-		var values = [T]()
-		try results { row in
-			values.append(try row.value(at: 0))
-		}
-		return values
+		return try column(0)
 	}
 }
 

--- a/FeistyDB/DatabaseSerializable.swift
+++ b/FeistyDB/DatabaseSerializable.swift
@@ -103,7 +103,7 @@ extension Statement {
 	/// - requires: `indexes.min() >= 0`
 	/// - requires: `indexes.max() < self.columnCount`
 	///
-	/// - parameter indexes: The indexes of the desired column
+	/// - parameter indexes: The indexes of the desired columns
 	///
 	/// - throws: An error if any element of `indexes` is out of bounds
 	public func columns<S: Collection, T: DatabaseSerializable>(_ indexes: S) throws -> [[T]] where S.Element == Int {

--- a/FeistyDB/DatabaseSerializable.swift
+++ b/FeistyDB/DatabaseSerializable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2015 - 2018 Feisty Dog, LLC
+// Copyright (c) 2015 - 2020 Feisty Dog, LLC
 //
 // See https://github.com/feistydog/FeistyDB/blob/master/LICENSE.txt for license information
 //

--- a/FeistyDB/DatabaseSerializable.swift
+++ b/FeistyDB/DatabaseSerializable.swift
@@ -96,17 +96,53 @@ extension Row {
 }
 
 extension Statement {
+	/// Returns the values of the columns at `indexes` for each row in the result set.
+	///
+	/// - note: Column indexes are 0-based.  The leftmost column in a row has index 0.
+	///
+	/// - requires: `indexes.min() >= 0`
+	/// - requires: `indexes.max() < self.columnCount`
+	///
+	/// - parameter indexes: The indexes of the desired column
+	///
+	/// - throws: An error if any element of `indexes` is out of bounds
+	public func columns<S: Collection, T: DatabaseSerializable>(_ indexes: S) throws -> [[T]] where S.Element == Int {
+		var values = [[T]](repeating: [], count: indexes.count)
+		try results { row in
+			for (n, x) in indexes.enumerated() {
+				values[n].append(try row.value(at: x))
+			}
+		}
+		return values
+	}
+
+	/// Returns the value of the column at `index` for each row in the result set.
+	///
+	/// - note: Column indexes are 0-based.  The leftmost column in a row has index 0.
+	///
+	/// - requires: `index >= 0`
+	/// - requires: `index < self.columnCount`
+	///
+	/// - parameter index: The index of the desired column
+	///
+	/// - throws: An error if `index` is out of bounds or the column contains a null or illegal value
+	public func column<T: DatabaseSerializable>(_ index: Int) throws -> [T] {
+		var values = [T]()
+		try results { row in
+			values.append(try row.value(at: index))
+		}
+		return values
+	}
+
 	/// Returns the value of the leftmost column for each row in the result set.
+	///
+	/// This is a shortcut for `column(0)`.
 	///
 	/// - throws: An error if there are no columns
 	///
 	/// - returns: An array containing the leftmost column's values
 	public func leftmostColumn<T: DatabaseSerializable>() throws -> [T] {
-		var values = [T]()
-		try results { row in
-			values.append(try row.value(at: 0))
-		}
-		return values
+		return try column(0)
 	}
 }
 

--- a/FeistyDB/DatabaseValue.swift
+++ b/FeistyDB/DatabaseValue.swift
@@ -174,17 +174,33 @@ extension Row {
 }
 
 extension Statement {
+	/// Returns the value of the column at `index` for each row in the result set.
+	///
+	/// - note: Column indexes are 0-based.  The leftmost column in a row has index 0.
+	///
+	/// - requires: `index >= 0`
+	/// - requires: `index < self.columnCount`
+	///
+	/// - parameter index: The index of the desired column
+	///
+	/// - throws: An error if `index` is out of bounds
+	public func column(_ index: Int) throws -> [DatabaseValue] {
+		var values = [DatabaseValue]()
+		try results { row in
+			values.append(try row.value(at: index))
+		}
+		return values
+	}
+
 	/// Returns the value of the leftmost column for each row in the result set.
+	///
+	/// This is a shortcut for `column(0)`.
 	///
 	/// - throws: An error if there are no columns
 	///
 	/// - returns: An array containing the leftmost column's values
 	public func leftmostColumn() throws -> [DatabaseValue] {
-		var values = [DatabaseValue]()
-		try results { row in
-			values.append(try row.value(at: 0))
-		}
-		return values
+		return try column(0)
 	}
 }
 

--- a/FeistyDB/DatabaseValue.swift
+++ b/FeistyDB/DatabaseValue.swift
@@ -178,17 +178,16 @@ extension Statement {
 	///
 	/// - note: Column indexes are 0-based.  The leftmost column in a row has index 0.
 	///
-	/// - requires: `indexes.startIndex >= 0`
-	/// - requires: `indexes.endIndex < self.columnCount`
+	/// - requires: `indexes.min() >= 0`
+	/// - requires: `indexes.max() < self.columnCount`
 	///
 	/// - parameter indexes: The indexes of the desired column
 	///
 	/// - throws: An error if any element of `indexes` is out of bounds
-	public func columns(_ indexes: IndexSet) throws -> [[DatabaseValue]] {
+	public func columns<S: Collection>(_ indexes: S) throws -> [[DatabaseValue]] where S.Element == Int {
 		var values = [[DatabaseValue]](repeating: [], count: indexes.count)
-		let sequence = indexes.enumerated()
 		try results { row in
-			for (n, x) in sequence {
+			for (n, x) in indexes.enumerated() {
 				values[n].append(try row.value(at: x))
 			}
 		}

--- a/FeistyDB/DatabaseValue.swift
+++ b/FeistyDB/DatabaseValue.swift
@@ -181,7 +181,7 @@ extension Statement {
 	/// - requires: `indexes.min() >= 0`
 	/// - requires: `indexes.max() < self.columnCount`
 	///
-	/// - parameter indexes: The indexes of the desired column
+	/// - parameter indexes: The indexes of the desired columns
 	///
 	/// - throws: An error if any element of `indexes` is out of bounds
 	public func columns<S: Collection>(_ indexes: S) throws -> [[DatabaseValue]] where S.Element == Int {

--- a/FeistyDB/DatabaseValue.swift
+++ b/FeistyDB/DatabaseValue.swift
@@ -174,6 +174,27 @@ extension Row {
 }
 
 extension Statement {
+	/// Returns the values of the columns at `indexes` for each row in the result set.
+	///
+	/// - note: Column indexes are 0-based.  The leftmost column in a row has index 0.
+	///
+	/// - requires: `indexes.startIndex >= 0`
+	/// - requires: `indexes.endIndex < self.columnCount`
+	///
+	/// - parameter indexes: The indexes of the desired column
+	///
+	/// - throws: An error if any element of `indexes` is out of bounds
+	public func columns(_ indexes: IndexSet) throws -> [[DatabaseValue]] {
+		var values = [[DatabaseValue]](repeating: [], count: indexes.count)
+		let sequence = indexes.enumerated()
+		try results { row in
+			for (n, x) in sequence {
+				values[n].append(try row.value(at: x))
+			}
+		}
+		return values
+	}
+
 	/// Returns the value of the column at `index` for each row in the result set.
 	///
 	/// - note: Column indexes are 0-based.  The leftmost column in a row has index 0.

--- a/FeistyDBTests/FeistyDBTests.swift
+++ b/FeistyDBTests/FeistyDBTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2015 - 2019 Feisty Dog, LLC
+// Copyright (c) 2015 - 2020 Feisty Dog, LLC
 //
 // See https://github.com/feistydog/FeistyDB/blob/master/LICENSE.txt for license information
 //
@@ -425,6 +425,21 @@ class FeistyDBTests: XCTestCase {
 			XCTAssertEqual(x, 5)
 			XCTAssertEqual(y, nil)
 		}
+	}
+
+	func testStatementColumns() {
+		let db = try! Database()
+
+		try! db.execute(sql: "create table t1(a, b, c);")
+
+		for i in 0..<3 {
+			try! db.prepare(sql: "insert into t1(a, b, c) values (?,?,?);").bind(parameterValues: [i, i * 3, i * 5]).execute()
+		}
+
+		let statement = try! db.prepare(sql: "select * from t1")
+		let cols: [[Int]] = try! statement.columns([0,2])
+		XCTAssertEqual(cols[0], [0,1,2])
+		XCTAssertEqual(cols[1], [0,5,10])
 	}
 
 	func testUUIDExtension() {


### PR DESCRIPTION
This PR adds `column(_:)` for a common use case